### PR TITLE
Fix package import recursion

### DIFF
--- a/src/FMNM/__init__.py
+++ b/src/FMNM/__init__.py
@@ -26,4 +26,25 @@ __all__ = [
     "VG_pricer",
 ]
 
-from FMNM import *
+# Explicitly import submodules so that they are available as attributes of the
+# package. Using relative imports avoids recursive imports that would occur with
+# ``from FMNM import *``.
+from . import (
+    cython,
+    BS_pricer,
+    CF,
+    cost_utils,
+    FFT,
+    Heston_pricer,
+    Kalman_filter,
+    Merton_pricer,
+    NIG_pricer,
+    Parameters,
+    portfolio_optimization,
+    probabilities,
+    Processes,
+    Solvers,
+    TC_pricer,
+    VG_pricer,
+)
+


### PR DESCRIPTION
## Summary
- avoid recursive import in `FMNM.__init__`
- import submodules explicitly so that package loads correctly

## Testing
- `python -m py_compile src/FMNM/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_683ffaabcecc83328997ad9c9d821ceb